### PR TITLE
Assign 25% CPU by default to serve light clients

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -173,7 +173,7 @@ var (
 	LightServFlag = cli.IntFlag{
 		Name:  "lightserv",
 		Usage: "Maximum percentage of time allowed for serving LES requests (0-90)",
-		Value: 0,
+		Value: 25,
 	}
 	LightPeersFlag = cli.IntFlag{
 		Name:  "lightpeers",


### PR DESCRIPTION
Longer term solution to issue #15454.
By making geth default behavior to serve light clients, we'll improve the overall network capacity and support the light client use case.